### PR TITLE
Override incorrect link colors on WP

### DIFF
--- a/src/sass/bootstrap4/_reboot.scss
+++ b/src/sass/bootstrap4/_reboot.scss
@@ -180,12 +180,12 @@ sup { top: -.5em; }
 //
 
 a {
-  color: $link-color;
+  color: #397aa6;
   text-decoration: $link-decoration;
   background-color: transparent; // Remove the gray background on active links in IE 10.
 
   @include hover {
-    color: $link-hover-color;
+    color: #2e5b83;
     text-decoration: $link-hover-decoration;
   }
 }


### PR DESCRIPTION
@dta121 hey, fixing the link coloring using the darker shades that are in the moodle-theme_saylor color indexing as well. Can you double check?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203150849931544