### PR TITLE
Correct button background color for accessibility

### DIFF
--- a/sass/theme/_child_theme_variables.scss
+++ b/sass/theme/_child_theme_variables.scss
@@ -53,7 +53,7 @@ $expand-orange-800:     #f16505 !default;
 $expand-orange-900:     #e84806 !default;
 
 // orange background color for buttons same as orange 800
-$button-bg-orange: #f16505 !default;
+$button-bg-orange: #D34203 !default;
 
 $expand-dark-blue-50:    #e2f0fe !default;
 $expand-dark-blue-100:   #c2d9e7 !default;

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Author:       Holger Koenemann, John Azinheira, Ryan Mcdonnell
  Author URI:   http://www.holgerkoenemann.de
  Template:     understrap
- Version:      1.2.2
+ Version:      1.2.3
  License: GNU General Public License v2 or later
  License URI: http://www.gnu.org/licenses/gpl-2.0.html
  Text Domain:  understrap-child


### PR DESCRIPTION
Fixed the button background color as well for the WP side, assuming that the saylorstrap changes are getting pushed live. 
<img width="1262" alt="Screen Shot 2022-10-18 at 2 30 33 PM" src="https://user-images.githubusercontent.com/9262502/196515680-2da49ebb-165f-405d-85e4-d478027da15e.png">

@dta121 